### PR TITLE
board-image/uboot-revyos-sipeed-lpi4a-8g: Bump to 0.20240720.0-matrix.bot

### DIFF
--- a/manifests/board-image/0.20240720.0-matrix.bot.toml
+++ b/manifests/board-image/0.20240720.0-matrix.bot.toml
@@ -1,0 +1,25 @@
+format = "v1"
+[[distfiles]]
+name = "u-boot-with-spl-lpi4a-16g.bin"
+size = 992696
+urls = [ "https://mirror.iscas.ac.cn/revyos/extra/images/lpi4a/20240720/u-boot-with-spl-lpi4a-16g.bin",]
+
+[distfiles.checksums]
+sha256 = "b193e0aebc272dbf775f30275f65463bcbd30b554da30db1e964697bb7e1a469"
+sha512 = "d5ed8199d6804d1740faae1458e0f20aa14400d39267ab3dc97b1bdb16512b3e44b3e01493f5bee2864e5c9ee7d92585d4a494e5efac0b2d86fe2e760909de1b"
+
+[metadata]
+desc = "U-Boot image for LicheePi 4A (16G RAM) and RevyOS 20240720"
+
+[blob]
+distfiles = [ "u-boot-with-spl-lpi4a-16g.20231210.bin",]
+
+[provisionable]
+strategy = "fastboot-v1(lpi4a-uboot)"
+
+[metadata.vendor]
+name = "PLCT"
+eula = ""
+
+[provisionable.partition_map]
+uboot = "u-boot-with-spl-lpi4a-16g.20231210.bin"

--- a/manifests/board-image/0.20240720.0-matrix.bot.toml
+++ b/manifests/board-image/0.20240720.0-matrix.bot.toml
@@ -1,18 +1,18 @@
 format = "v1"
 [[distfiles]]
-name = "u-boot-with-spl-lpi4a-16g.bin"
-size = 992696
-urls = [ "https://mirror.iscas.ac.cn/revyos/extra/images/lpi4a/20240720/u-boot-with-spl-lpi4a-16g.bin",]
+name = "u-boot-with-spl-vala.bin"
+size = 1034448
+urls = [ "https://mirror.iscas.ac.cn/revyos/extra/images/lpi4a/20240720/u-boot-with-spl-vala.bin",]
 
 [distfiles.checksums]
-sha256 = "b193e0aebc272dbf775f30275f65463bcbd30b554da30db1e964697bb7e1a469"
-sha512 = "d5ed8199d6804d1740faae1458e0f20aa14400d39267ab3dc97b1bdb16512b3e44b3e01493f5bee2864e5c9ee7d92585d4a494e5efac0b2d86fe2e760909de1b"
+sha256 = "2d462ac8c5853abc8981275863bdaf7c58cb60a627e31fefe7ca59ed55bf973a"
+sha512 = "b992245e67c6e1545b470e8f4180da8ee7b616fbd90def77fb1d3d80b816765a88a66134fab266bd8ec483a83a64ba50b656f29029031e7672274332eadd9d63"
 
 [metadata]
 desc = "U-Boot image for LicheePi 4A (16G RAM) and RevyOS 20240720"
 
 [blob]
-distfiles = [ "u-boot-with-spl-lpi4a-16g.20231210.bin",]
+distfiles = [ "u-boot-with-spl-lpi4a-8g.20231210.bin",]
 
 [provisionable]
 strategy = "fastboot-v1(lpi4a-uboot)"
@@ -22,4 +22,4 @@ name = "PLCT"
 eula = ""
 
 [provisionable.partition_map]
-uboot = "u-boot-with-spl-lpi4a-16g.20231210.bin"
+uboot = "u-boot-with-spl-lpi4a-8g.20231210.bin"


### PR DESCRIPTION
Bump uboot-revyos-sipeed-lpi4a-8g from 0.20231210.0 to 0.20240720.0-matrix.bot.

Identifier: [HASH[f1ad75b22c2284d1f8f7690207fd5425c99e032b43b68d4957d0175a]]

This PR is made by ruyi-index-updator bot.
