### PR TITLE
board-image/revyos-sipeed-lpi4a: Bump to 0.20240720.0-matrix.bot

### DIFF
--- a/manifests/board-image/revyos-sipeed-lpi4a/0.20240720.0.toml
+++ b/manifests/board-image/revyos-sipeed-lpi4a/0.20240720.0.toml
@@ -1,0 +1,38 @@
+format = "v1"
+[[distfiles]]
+name = "root-lpi4a-20240720_171951.ext4.zst"
+size = 1245333733
+urls = [ "https://mirror.iscas.ac.cn/revyos/extra/images/lpi4a/20240720/root-lpi4a-20240720_171951.ext4.zst",]
+
+[distfiles.checksums]
+sha256 = "a300e2bfba85e4d87955b6875d52254c81f98e5026e3563def59919cd08e099d"
+sha512 = "6e32680ecffbfdd031563b9fe9a998533d03bcc03ed5ce7f4fd4033077a8e4f211b3b7b0409502ae1a0dfe72ce7b7073393f23b6724c8780b5a434dc478fc5d5"
+[[distfiles]]
+name = "boot-lpi4a-20240720_171951.ext4.zst"
+size = 28604077
+urls = [ "https://mirror.iscas.ac.cn/revyos/extra/images/lpi4a/20240720/boot-lpi4a-20240720_171951.ext4.zst",]
+
+[distfiles.checksums]
+sha256 = "4050dcd4921d57bf342c12c690ec14075adab2233d8f57cb79a0568de99bd348"
+sha512 = "ad0e5e088f9cb7deccb7251bf36b8b2c0fa03eeeeea02c19d695d67a09fd4e9c9cf1de6f62775463c715d4868e3af2110ded3635d3f77a75e849163c0fd89ff5"
+
+[metadata]
+desc = "RevyOS 20240720 image for Sipeed LicheePi 4A"
+
+[blob]
+distfiles = [ "root-lpi4a-20240720_171951.ext4.zst", "boot-lpi4a-20240720_171951.ext4.zst",]
+
+[provisionable]
+strategy = "fastboot-v1"
+
+[metadata.vendor]
+name = "PLCT"
+eula = ""
+
+[provisionable.partition_map]
+boot = "boot-lpi4a-20240720_171951.ext4"
+root = "root-lpi4a-20240720_171951.ext4"
+
+# This file is created by CI Sync Package Index inside support-matrix
+# Run ID: 12135888972
+# Run URL: https://github.com/wychlw/support-matrix/actions/runs/12135888972


### PR DESCRIPTION
Bump revyos-sipeed-lpi4a from 0.20231210.0 to 0.20240720.0-matrix.bot.

Identifier: [HASH[aa9a7a87f6e08bd49a81dce55770765cf0fcdb5569864d91116af147]]

This PR is made by ruyi-index-updator bot.
