### PR TITLE
board-image/uboot-revyos-sipeed-lpi4a-8g: Bump to 0.20240720.0-matrix.bot

### DIFF
--- a/manifests/board-image/0.20240720.0.toml
+++ b/manifests/board-image/0.20240720.0.toml
@@ -1,0 +1,25 @@
+format = "v1"
+[[distfiles]]
+name = "u-boot-with-spl-lpi4a.20240720.bin"
+size = 1032280
+urls = [ "https://mirror.iscas.ac.cn/revyos/extra/images/lpi4a/20240720/u-boot-with-spl-lpi4a.bin",]
+
+[distfiles.checksums]
+sha256 = "d3d173513290289ac8a4c9ef2ec2943ca6e23f1eebbc806a13f6ced91c22b093"
+sha512 = "a732e09c7c3c8b508ad0da8ca4110bdae5a1c6e423ac4f93b0645c150a513fff0df0ed3a5352110563aa4c92b63d5746009c0ce777cf20fca84710edac42d730"
+
+[metadata]
+desc = "U-Boot image for LicheePi 4A (8G RAM) and RevyOS 20240720"
+
+[blob]
+distfiles = [ "u-boot-with-spl-lpi4a.20240720.bin",]
+
+[provisionable]
+strategy = "fastboot-v1(lpi4a-uboot)"
+
+[metadata.vendor]
+name = "PLCT"
+eula = ""
+
+[provisionable.partition_map]
+uboot = "u-boot-with-spl-lpi4a.20240720.bin"

--- a/manifests/board-image/revyos-sipeed-lpi4a/0.20240720.0.toml
+++ b/manifests/board-image/revyos-sipeed-lpi4a/0.20240720.0.toml
@@ -1,0 +1,38 @@
+format = "v1"
+[[distfiles]]
+name = "root-lpi4a-20240720_171951.ext4.zst"
+size = 1245333733
+urls = [ "https://mirror.iscas.ac.cn/revyos/extra/images/lpi4a/20240720/root-lpi4a-20240720_171951.ext4.zst",]
+
+[distfiles.checksums]
+sha256 = "a300e2bfba85e4d87955b6875d52254c81f98e5026e3563def59919cd08e099d"
+sha512 = "6e32680ecffbfdd031563b9fe9a998533d03bcc03ed5ce7f4fd4033077a8e4f211b3b7b0409502ae1a0dfe72ce7b7073393f23b6724c8780b5a434dc478fc5d5"
+[[distfiles]]
+name = "boot-lpi4a-20240720_171951.ext4.zst"
+size = 28604077
+urls = [ "https://mirror.iscas.ac.cn/revyos/extra/images/lpi4a/20240720/boot-lpi4a-20240720_171951.ext4.zst",]
+
+[distfiles.checksums]
+sha256 = "4050dcd4921d57bf342c12c690ec14075adab2233d8f57cb79a0568de99bd348"
+sha512 = "ad0e5e088f9cb7deccb7251bf36b8b2c0fa03eeeeea02c19d695d67a09fd4e9c9cf1de6f62775463c715d4868e3af2110ded3635d3f77a75e849163c0fd89ff5"
+
+[metadata]
+desc = "RevyOS 20240720 image for Sipeed LicheePi 4A"
+
+[blob]
+distfiles = [ "root-lpi4a-20240720_171951.ext4.zst", "boot-lpi4a-20240720_171951.ext4.zst",]
+
+[provisionable]
+strategy = "fastboot-v1"
+
+[metadata.vendor]
+name = "PLCT"
+eula = ""
+
+[provisionable.partition_map]
+boot = "boot-lpi4a-20240720_171951.ext4"
+root = "root-lpi4a-20240720_171951.ext4"
+
+# This file is created by CI Sync Package Index inside support-matrix
+# Run ID: 12135888972
+# Run URL: https://github.com/wychlw/support-matrix/actions/runs/12135888972

--- a/manifests/board-image/uboot-revyos-sipeed-lpi4a-16g/0.20240720.0.toml
+++ b/manifests/board-image/uboot-revyos-sipeed-lpi4a-16g/0.20240720.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+[[distfiles]]
+name = "u-boot-with-spl-lpi4a-16g.20240720.bin"
+size = 992696
+urls = [ "https://mirror.iscas.ac.cn/revyos/extra/images/lpi4a/20240720/u-boot-with-spl-lpi4a-16g.bin",]
+
+[distfiles.checksums]
+sha256 = "b193e0aebc272dbf775f30275f65463bcbd30b554da30db1e964697bb7e1a469"
+sha512 = "d5ed8199d6804d1740faae1458e0f20aa14400d39267ab3dc97b1bdb16512b3e44b3e01493f5bee2864e5c9ee7d92585d4a494e5efac0b2d86fe2e760909de1b"
+
+[metadata]
+desc = "U-Boot image for LicheePi 4A (16G RAM) and RevyOS 20240720"
+
+[blob]
+distfiles = [ "u-boot-with-spl-lpi4a-16g.20240720.bin",]
+
+[provisionable]
+strategy = "fastboot-v1(lpi4a-uboot)"
+
+[metadata.vendor]
+name = "PLCT"
+eula = ""
+
+[provisionable.partition_map]
+uboot = "u-boot-with-spl-lpi4a-16g.20240720.bin"
+
+# This file is created by CI Sync Package Index inside support-matrix
+# Run ID: 12135888972
+# Run URL: https://github.com/wychlw/support-matrix/actions/runs/12135888972

--- a/manifests/board-image/uboot-revyos-sipeed-lpi4a-8g/0.20240720.0.toml
+++ b/manifests/board-image/uboot-revyos-sipeed-lpi4a-8g/0.20240720.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+[[distfiles]]
+name = "u-boot-with-spl-lpi4a-8g.20240720.bin"
+size = 1032280
+urls = [ "https://mirror.iscas.ac.cn/revyos/extra/images/lpi4a/20240720/u-boot-with-spl-lpi4a.bin",]
+
+[distfiles.checksums]
+sha256 = "d3d173513290289ac8a4c9ef2ec2943ca6e23f1eebbc806a13f6ced91c22b093"
+sha512 = "a732e09c7c3c8b508ad0da8ca4110bdae5a1c6e423ac4f93b0645c150a513fff0df0ed3a5352110563aa4c92b63d5746009c0ce777cf20fca84710edac42d730"
+
+[metadata]
+desc = "U-Boot image for LicheePi 4A (8G RAM) and RevyOS 20240720"
+
+[blob]
+distfiles = [ "u-boot-with-spl-lpi4a-8g.20240720.bin",]
+
+[provisionable]
+strategy = "fastboot-v1(lpi4a-uboot)"
+
+[metadata.vendor]
+name = "PLCT"
+eula = ""
+
+[provisionable.partition_map]
+uboot = "u-boot-with-spl-lpi4a-8g.20240720.bin"
+
+# This file is created by CI Sync Package Index inside support-matrix
+# Run ID: 12135888972
+# Run URL: https://github.com/wychlw/support-matrix/actions/runs/12135888972


### PR DESCRIPTION
Bump uboot-revyos-sipeed-lpi4a-8g from 0.20231210.0 to 0.20240720.0-matrix.bot.

Identifier: [HASH[2370c6be8a7407439531dbb38567c9f6f7dfcb649e1ae1a88d332e4a]]

This PR is made by ruyi-index-updator bot.
