### PR TITLE
board-image/revyos-sipeed-lpi4a: Bump to 0.20241229.0

### DIFF
--- a/manifests/board-image/revyos-sipeed-lpi4a/0.20241229.0.toml
+++ b/manifests/board-image/revyos-sipeed-lpi4a/0.20241229.0.toml
@@ -33,6 +33,5 @@ eula = ""
 boot = "u-boot-with-spl-lpi4a-main_8gemmc"
 root = "root-lpi4a-20241229_032148.ext4"
 
-# This file is created by CI Sync Package Index inside support-matrix
-# Run ID: 12655435394
-# Run URL: https://github.com/ruyisdk/support-matrix/actions/runs/12655435394
+# This file is created by program renew_ruyi_index in support-matrix
+# Run: In local


### PR DESCRIPTION
Bump revyos-sipeed-lpi4a from 0.20241229.0 to 0.20241229.0.

Identifier: [HASH[6b6a149b0a4f10bca1b6004f383d3bb1251ee925a823d270b06d9389]]

This PR is made by ruyi-index-updater bot.
