### PR TITLE
board-image/revyos-sipeed-lc4a: Bump to 0.20240127.0

### DIFF
--- a/manifests/board-image/revyos-sipeed-lc4a/0.20240127.0.toml
+++ b/manifests/board-image/revyos-sipeed-lc4a/0.20240127.0.toml
@@ -1,42 +1,37 @@
 format = "v1"
-
-[metadata]
-desc = "RevyOS 20240127 image for Sipeed Lichee Cluster 4A"
-vendor = { name = "PLCT", eula = "" }
-
-[[distfiles]]
-name = "boot-lpi4amain-20240127_105111.ext4.zst"
-size = 82431352
-urls = [
-  "https://mirror.iscas.ac.cn/revyos/extra/images/lpi4amain/20240127/boot-lpi4amain-20240127_105111.ext4.zst",
-]
-restrict = ["mirror"]
-
-[distfiles.checksums]
-sha256 = "52d4026c1dfc1be5075855fac14454438082cb79c9ce0a41f0ff20796fe0f0d0"
-sha512 = "565e8568f3580178b61dd34309df19dd101fd5ecc1106b2b5438774a3618779905e8a69bbb7c49e3640c2177879f4b94d274d43e0c3028da7d72ee1aecf19408"
-
 [[distfiles]]
 name = "root-lpi4amain-20240127_105111.ext4.zst"
 size = 1286756863
-urls = [
-  "https://mirror.iscas.ac.cn/revyos/extra/images/lpi4amain/20240127/root-lpi4amain-20240127_105111.ext4.zst",
-]
-restrict = ["mirror"]
+urls = [ "https://mirror.iscas.ac.cn/revyos/extra/images/lpi4amain/20240127/root-lpi4amain-20240127_105111.ext4.zst",]
 
 [distfiles.checksums]
 sha256 = "46919f8de6d4642b3e34c31aa1a264e9014ae3593d79a39ed3ab9b9f7a2cd23d"
 sha512 = "10d2cc5b19227ed1bb301ef7c6d13b2170a4ebe8fca4c5af2afadc1ac7ec62f82cef446a46da8934fec25a0d443af954d63e2aab91f4dc9a0d614c53962d8fe2"
+[[distfiles]]
+name = "u-boot-with-spl-lpi4a-main.bin"
+size = 1033904
+urls = [ "https://mirror.iscas.ac.cn/revyos/extra/images/lpi4amain/20240127/u-boot-with-spl-lpi4a-main.bin",]
+
+[distfiles.checksums]
+sha256 = "b094d5f940085f0125e82532b9bc0e62e567cd15e6bbda483842b937f0e5971b"
+sha512 = "2e1c8287842bbe8eabf8f431c643411fdf4e8800a41b2c44920b4fbad882475046ed0e715f139ecce6558b2529b6acd51cdb22a2e903871fc757af17b67a03cf"
+
+[metadata]
+desc = "RevyOS 20240127 image for Sipeed LicheeCluster 4A"
 
 [blob]
-distfiles = [
-  "boot-lpi4amain-20240127_105111.ext4.zst",
-  "root-lpi4amain-20240127_105111.ext4.zst",
-]
+distfiles = [ "root-lpi4amain-20240127_105111.ext4.zst", "u-boot-with-spl-lpi4a-main.bin",]
 
 [provisionable]
 strategy = "fastboot-v1"
 
+[metadata.vendor]
+name = "PLCT"
+eula = ""
+
 [provisionable.partition_map]
-boot = "boot-lpi4amain-20240127_105111.ext4"
+boot = "u-boot-with-spl-lpi4a-main"
 root = "root-lpi4amain-20240127_105111.ext4"
+
+# This file is created by program renew_ruyi_index in support-matrix
+# Run: In local


### PR DESCRIPTION
Bump revyos-sipeed-lc4a from 0.20240127.0 to 0.20240127.0.

Identifier: [HASH[f5cdc532913dbdb4799330deb202d140703e848d1cd7f0476df37e1c]]

This PR is made by ruyi-index-updater bot.
