### PR TITLE
board-image/uboot-revyos-sipeed-lc4a-16g: Bump to 0.20240127.0

### DIFF
--- a/manifests/board-image/uboot-revyos-sipeed-lc4a-16g/0.20240127.0.toml
+++ b/manifests/board-image/uboot-revyos-sipeed-lc4a-16g/0.20240127.0.toml
@@ -1,29 +1,28 @@
 format = "v1"
-
-[metadata]
-desc = "U-Boot image for Sipeed Lichee Cluster 4A (16G RAM) and RevyOS 20240127"
-vendor = { name = "PLCT", eula = "" }
-
 [[distfiles]]
-name = "u-boot-with-spl-lc4a-16g-main.bin"
-unpack = "raw"
+name = "u-boot-with-spl-lc4a-16g-main.20240127.bin"
 size = 968944
-urls = [
-  "https://mirror.iscas.ac.cn/revyos/extra/images/lpi4amain/20240127/u-boot-with-spl-lc4a-16g-main.bin",
-]
-restrict = ["mirror"]
+urls = [ "https://mirror.iscas.ac.cn/revyos/extra/images/lpi4amain/20240127/u-boot-with-spl-lc4a-16g-main.bin",]
 
 [distfiles.checksums]
 sha256 = "f4a72fa87f807e359a3eac1f3f89229bf646f3e996b39ce79bdf862cb16183ca"
 sha512 = "8983b69dd4e5e14af3058c4795efc3e0bda8f1830930b9b72ff55ae991fe8a7603dfea6438334a3419becf818a077f4dc5586e413b457f8af20a5551085f9106"
 
+[metadata]
+desc = "U-Boot image for LicheeCluster 4A (16G RAM) and RevyOS 20240127"
+
 [blob]
-distfiles = [
-  "u-boot-with-spl-lc4a-16g-main.bin",
-]
+distfiles = [ "u-boot-with-spl-lc4a-16g-main.20240127.bin",]
 
 [provisionable]
 strategy = "fastboot-v1(lpi4a-uboot)"
 
+[metadata.vendor]
+name = "PLCT"
+eula = ""
+
 [provisionable.partition_map]
-uboot = "u-boot-with-spl-lc4a-16g-main.bin"
+uboot = "u-boot-with-spl-lc4a-16g-main.20240127.bin"
+
+# This file is created by program renew_ruyi_index in support-matrix
+# Run: In local


### PR DESCRIPTION
Bump uboot-revyos-sipeed-lc4a-16g from 0.20240127.0 to 0.20240127.0.

Identifier: [HASH[28fced56ffea41f1892b166f15e2e2eae8670b1b8a16f4b1160b219a]]

This PR is made by ruyi-index-updater bot.
