### PR TITLE
board-image/uboot-revyos-sipeed-lc4a-8g: Bump to 0.20240127.0

### DIFF
--- a/manifests/board-image/uboot-revyos-sipeed-lc4a-8g/0.20240127.0.toml
+++ b/manifests/board-image/uboot-revyos-sipeed-lc4a-8g/0.20240127.0.toml
@@ -1,29 +1,28 @@
 format = "v1"
-
-[metadata]
-desc = "U-Boot image for Sipeed Lichee Cluster 4A (8G RAM) and RevyOS 20240127"
-vendor = { name = "PLCT", eula = "" }
-
 [[distfiles]]
-name = "u-boot-with-spl-lc4a-main.bin"
-unpack = "raw"
+name = "u-boot-with-spl-lc4a-main.20240127.bin"
 size = 968928
-urls = [
-  "https://mirror.iscas.ac.cn/revyos/extra/images/lpi4amain/20240127/u-boot-with-spl-lc4a-main.bin",
-]
-restrict = ["mirror"]
+urls = [ "https://mirror.iscas.ac.cn/revyos/extra/images/lpi4amain/20240127/u-boot-with-spl-lc4a-main.bin",]
 
 [distfiles.checksums]
 sha256 = "b3d46d1fb0045e88a4514fd6ecd0ae5364b18df08edf974b1af1efa8a5aef406"
 sha512 = "143c93e8c1f0693d4609aa41f1bafce22815f9d8c1f181ec99eaeb3ab8f97e002c4c454cd31904f52d2d3993691524004d4eaf2ad4779cfbc7d898e9d71b185e"
 
+[metadata]
+desc = "U-Boot image for LicheeCluster 4A (8G RAM) and RevyOS 20240127"
+
 [blob]
-distfiles = [
-  "u-boot-with-spl-lc4a-main.bin",
-]
+distfiles = [ "u-boot-with-spl-lc4a-main.20240127.bin",]
 
 [provisionable]
 strategy = "fastboot-v1(lpi4a-uboot)"
 
+[metadata.vendor]
+name = "PLCT"
+eula = ""
+
 [provisionable.partition_map]
-uboot = "u-boot-with-spl-lc4a-main.bin"
+uboot = "u-boot-with-spl-lc4a-main.20240127.bin"
+
+# This file is created by program renew_ruyi_index in support-matrix
+# Run: In local


### PR DESCRIPTION
Bump uboot-revyos-sipeed-lc4a-8g from 0.20240127.0 to 0.20240127.0.

Identifier: [HASH[d5fe0438e172d46e086dcead954a2e76cf3cdbb77eaf53a7303b3745]]

This PR is made by ruyi-index-updater bot.
