### PR TITLE
board-image/buildroot-sdk-milkv-duo: Bump to 1.1.4

### DIFF
--- a/manifests/board-image/buildroot-sdk-milkv-duo/1.1.4.toml
+++ b/manifests/board-image/buildroot-sdk-milkv-duo/1.1.4.toml
@@ -1,0 +1,28 @@
+format = "v1"
+[[distfiles]]
+name = "milkv-duo-sd-v1.1.4.img.zip"
+size = 71229335
+urls = [ "https://github.com/milkv-duo/duo-buildroot-sdk/releases/download/v1.1.4/milkv-duo-sd-v1.1.4.img.zip",]
+
+[distfiles.checksums]
+sha256 = "271a24958e637f7101ca93f10a57a3a8f1afa9f100710462cd689c795bc01e4a"
+sha512 = "6d3178b154bd55b4dc55a8392ac3556a1b36fea957885be7c683dcb7302f061fdfd5d5212d0224da5cde18705befa3ab71d3d301d03ca020e1a2820aa53576aa"
+
+[metadata]
+desc = "Official Buildroot SDK image for Milk-V Duo (64M RAM) milkv-duo-sd-v1.1.4.img.zip"
+
+[blob]
+distfiles = [ "milkv-duo-sd-v1.1.4.img.zip",]
+
+[provisionable]
+strategy = "dd-v1"
+
+[metadata.vendor]
+name = "Milk-V"
+eula = ""
+
+[provisionable.partition_map]
+disk = "milkv-duo-sd-v1.1.4.img"
+
+# This file is created by program renew_ruyi_index in support-matrix
+# Run: In local


### PR DESCRIPTION
Bump buildroot-sdk-milkv-duo from 1.1.3 to 1.1.4.

Identifier: [HASH[c54d6cb9dfb4e231d1b7a1367f9c0eced46e38fe4586424221c53ba0]]

This PR is made by ruyi-index-updater bot.
