### PR TITLE
board-image/uboot-revyos-sipeed-lpi4a-16g: Bump to 0.20250110.0

### DIFF
--- a/manifests/board-image/uboot-revyos-sipeed-lpi4a-16g/0.20250110.0.toml
+++ b/manifests/board-image/uboot-revyos-sipeed-lpi4a-16g/0.20250110.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+[[distfiles]]
+name = "u-boot-with-spl-lpi4a-16g-main.20250110.bin"
+size = 992728
+urls = [ "https://mirror.iscas.ac.cn/revyos/extra/images/lpi4a/20250110/u-boot-with-spl-lpi4a-16g-main.bin",]
+
+[distfiles.checksums]
+sha256 = "946ef12ac79f59a6f43c63c534477776d2b07d7ce8919f4c7d05ed29ddfad30d"
+sha512 = "e626d1ee7617095179fa31394bf0f129225be9527b9042d62957051b11303298d3c46fe0c2d053046cde192c3cf62ea687f4616028f499927603a50bd39144c8"
+
+[metadata]
+desc = "U-Boot image for LicheePi 4A (16G RAM) and RevyOS 20250110"
+
+[blob]
+distfiles = [ "u-boot-with-spl-lpi4a-16g-main.20250110.bin",]
+
+[provisionable]
+strategy = "fastboot-v1(lpi4a-uboot)"
+
+[metadata.vendor]
+name = "PLCT"
+eula = ""
+
+[provisionable.partition_map]
+uboot = "u-boot-with-spl-lpi4a-16g-main.20250110.bin"
+
+# This file is created by CI Sync Package Index inside support-matrix
+# Run ID: 12909642299
+# Run URL: https://github.com/wychlw/support-matrix/actions/runs/12909642299


### PR DESCRIPTION
Bump uboot-revyos-sipeed-lpi4a-16g from 0.20240720.0 to 0.20250110.0.

Identifier: [HASH[e59121affa3dc58cce4056a15735e8f2c8d13e834785afd9ccd1bcc9]]

This PR is made by ruyi-index-updator bot.
