### PR TITLE
Bump image buildroot in device milkv-duo to version v2.0.0

### DIFF
--- a/manifests/board-image/buildroot-sdk-milkv-duo-v2/2.0.0-0.toml
+++ b/manifests/board-image/buildroot-sdk-milkv-duo-v2/2.0.0-0.toml
@@ -1,0 +1,32 @@
+format = "v1"
+[[distfiles]]
+name = "milkv-duo-musl-riscv64-sd_v2.0.0.img.zip"
+size = 63204048
+urls = [ "https://github.com/milkv-duo/duo-buildroot-sdk-v2/releases/download/v2.0.0/milkv-duo-musl-riscv64-sd_v2.0.0.img.zip",]
+restrict = [ "mirror",]
+
+[distfiles.checksums]
+sha256 = "893d876be93e70079d9acaf0ea57704e470b2fb540616fd3d943615fccfd6369"
+sha512 = "18f25ecdf0b545534877e56c84d1b2b31c3e92aa801192fcd856c9ed743578c4e506b77b139f2895a833a5355386b025f7d9de506a5b86b788c31cd49a97e20a"
+
+[metadata]
+desc = "buildroot v2 for Milk-V Duo (64M) with version v2.0.0"
+service_level = []
+upstream_version = "v2.0.0"
+
+[blob]
+distfiles = [ "milkv-duo-musl-riscv64-sd_v2.0.0.img.zip",]
+
+[provisionable]
+strategy = "dd_v1"
+
+[metadata.vendor]
+name = "milkv-duo"
+eula = ""
+
+[provisionable.partition_map]
+disk = "milkv-duo-musl-riscv64-sd_v2.0.0.img"
+
+# This file is created by program Sync Package Index inside support-matrix
+# Run ID: 14351018419
+# Run URL: https://github.com/wychlw/support-matrix/actions/runs/14351018419

--- a/provisioner/config.yml
+++ b/provisioner/config.yml
@@ -519,6 +519,10 @@ image_combos:
     display_name: bianbu  for BananaPi BPI-F3
     packages:
       - board-image/bianbu-bpi-f3
+  - id: buildroot-sdk-milkv-duo-64m-v2
+    display_name: buildroot v2 for Milk-V Duo (64M)
+    packages:
+      - board-image/buildroot-sdk-milkv-duo-64m-v2
 devices:
   - id: awol-d1dev
     display_name: "Allwinner Nezha D1"
@@ -564,6 +568,7 @@ devices:
           - arduino-milkv-duo-sd
           - buildroot-sdk-milkv-duo
           - buildroot-sdk-milkv-duo-python
+          - buildroot-sdk-milkv-duo-64m-v2
       - id: 256m
         display_name: "Milk-V Duo (256M RAM)"
         supported_combos:


### PR DESCRIPTION

Bump image buildroot in device milkv-duo to version v2.0.0

Ident: 4addfe94b500d13dfaa3fec0697c784575c39b4eed4f0ec32d32942749b330ce

This PR is created by program Sync Package Index inside support-matrix

Run ID: 14351018419
Run URL: https://github.com/wychlw/support-matrix/actions/runs/14351018419
