### PR TITLE
Bump image buildroot in device milkv-duo to version v2.0.0

### DIFF
--- a/manifests/board-image/buildroot-sdk-milkv-duo-v2/2.0.0-0.toml
+++ b/manifests/board-image/buildroot-sdk-milkv-duo-v2/2.0.0-0.toml
@@ -1,0 +1,32 @@
+format = "v1"
+[[distfiles]]
+name = "milkv-duo256m-musl-riscv64-sd_v2.0.0.img.zip"
+size = 63544801
+urls = [ "https://github.com/milkv-duo/duo-buildroot-sdk-v2/releases/download/v2.0.0/milkv-duo256m-musl-riscv64-sd_v2.0.0.img.zip",]
+restrict = [ "mirror",]
+
+[distfiles.checksums]
+sha256 = "baaf8fc9e7de40c4dc2d7c6c9d5d8f16a3c871ce98c0c0451733ffdd7efc3fec"
+sha512 = "40987a69b22fc65c044ec911f328a5da82bc0a54c9f35d9e436210498a1f048204d66fdf5249f2cdd7a7a53bf635df82934cc8829df6b3ec91ae1c5608d64786"
+
+[metadata]
+desc = "buildroot v2 for Milk-V Duo (256M) with version v2.0.0"
+service_level = []
+upstream_version = "v2.0.0"
+
+[blob]
+distfiles = [ "milkv-duo256m-musl-riscv64-sd_v2.0.0.img.zip",]
+
+[provisionable]
+strategy = "dd_v1"
+
+[metadata.vendor]
+name = "milkv-duo"
+eula = ""
+
+[provisionable.partition_map]
+disk = "milkv-duo256m-musl-riscv64-sd_v2.0.0.img"
+
+# This file is created by program Sync Package Index inside support-matrix
+# Run ID: 14352077316
+# Run URL: https://github.com/wychlw/support-matrix/actions/runs/14352077316

--- a/provisioner/config.yml
+++ b/provisioner/config.yml
@@ -519,6 +519,10 @@ image_combos:
     display_name: bianbu  for BananaPi BPI-F3
     packages:
       - board-image/bianbu-bpi-f3
+  - id: buildroot-sdk-milkv-duo-256m-v2
+    display_name: buildroot v2 for Milk-V Duo (256M)
+    packages:
+      - board-image/buildroot-sdk-milkv-duo-256m-v2
 devices:
   - id: awol-d1dev
     display_name: "Allwinner Nezha D1"
@@ -571,6 +575,7 @@ devices:
           - buildroot-sdk-milkv-duo256m
           - buildroot-sdk-milkv-duo256m-python
 
+          - buildroot-sdk-milkv-duo-256m-v2
   - id: milkv-duos
     display_name: "Milk-V Duo S"
     variants:


### PR DESCRIPTION

Bump image buildroot in device milkv-duo to version v2.0.0

Ident: df6e1d05e6d0e151c1ad9a5065d126c55539cf820978619935c40d111ba5b435

This PR is created by program Sync Package Index inside support-matrix

Run ID: 14352077316
Run URL: https://github.com/wychlw/support-matrix/actions/runs/14352077316
