### PR TITLE
Bump image buildroot in device milkv-duos to version v2.0.0

### DIFF
--- a/manifests/board-image/buildroot-sdk-milkv-duos-sd-v2/2.0.0-0.toml
+++ b/manifests/board-image/buildroot-sdk-milkv-duos-sd-v2/2.0.0-0.toml
@@ -1,0 +1,32 @@
+format = "v1"
+[[distfiles]]
+name = "milkv-duos-musl-riscv64-sd_v2.0.0.img.zip"
+size = 70543302
+urls = [ "https://github.com/milkv-duo/duo-buildroot-sdk-v2/releases/download/v2.0.0/milkv-duos-musl-riscv64-sd_v2.0.0.img.zip",]
+restrict = [ "mirror",]
+
+[distfiles.checksums]
+sha256 = "04b88c4c43adeee2c7c266188d39c7bc3c54fdc1f1d317bded5a7afe6844a1e8"
+sha512 = "5f64d92c08b589af18505e71199e7b7e1e14dc6fe0ddb3800853caf85372765863dd25c29d8fb5eb799873241ac084f9231ea33bd2debefcb76e93ace381061e"
+
+[metadata]
+desc = "buildroot sd-v2 for Milk-V Duo S with version v2.0.0"
+service_level = []
+upstream_version = "v2.0.0"
+
+[blob]
+distfiles = [ "milkv-duos-musl-riscv64-sd_v2.0.0.img.zip",]
+
+[provisionable]
+strategy = "dd_v1"
+
+[metadata.vendor]
+name = "milkv-duos"
+eula = ""
+
+[provisionable.partition_map]
+disk = "milkv-duos-musl-riscv64-sd_v2.0.0.img"
+
+# This file is created by program Sync Package Index inside support-matrix
+# Run ID: 14352219321
+# Run URL: https://github.com/wychlw/support-matrix/actions/runs/14352219321

--- a/provisioner/config.yml
+++ b/provisioner/config.yml
@@ -519,6 +519,10 @@ image_combos:
     display_name: bianbu  for BananaPi BPI-F3
     packages:
       - board-image/bianbu-bpi-f3
+  - id: buildroot-sdk-milkv-duos-sd-v2
+    display_name: buildroot sd-v2 for Milk-V Duo S
+    packages:
+      - board-image/buildroot-sdk-milkv-duos-sd-v2
 devices:
   - id: awol-d1dev
     display_name: "Allwinner Nezha D1"
@@ -579,6 +583,7 @@ devices:
         supported_combos:
           - buildroot-milkv-duos-sd
 
+          - buildroot-sdk-milkv-duos-sd-v2
   - id: milkv-mars
     display_name: "Milk-V Mars"
     variants:


### PR DESCRIPTION

Bump image buildroot in device milkv-duos to version v2.0.0

Ident: b8f9439b5382ac6c6ca7e79ab47083c7574bba19094b98764a2bc2c452876d99

This PR is created by program Sync Package Index inside support-matrix

Run ID: 14352219321
Run URL: https://github.com/wychlw/support-matrix/actions/runs/14352219321
