### PR TITLE
Bump image debian in device milkv-duos to version v1.4.0

### DIFF
--- a/manifests/board-image/debian-milkv-duos-sd/1.4.0-0.toml
+++ b/manifests/board-image/debian-milkv-duos-sd/1.4.0-0.toml
@@ -1,0 +1,32 @@
+format = "v1"
+[[distfiles]]
+name = "duos_sd.img.lz4"
+size = 202056832
+urls = [ "https://github.com/Fishwaldo/sophgo-sg200x-debian/releases/download/v1.4.0/duos_sd.img.lz4",]
+restrict = [ "mirror",]
+
+[distfiles.checksums]
+sha256 = "2061c6f72311cf4803388ff9f8daab0d4f40deefae2ba39ecd271f9f07d82890"
+sha512 = "a4b7f8b7cc0f442cd4bb257f3030bde47d9fb1b8114968baa195344852fcffc0fe43a39389f771d9e0de93eaf2252d7f3f1ada4b4fe1ce6a6819c2fc176f454d"
+
+[metadata]
+desc = "debian sd for Milk-V Duo S with version v1.4.0"
+service_level = []
+upstream_version = "v1.4.0"
+
+[blob]
+distfiles = [ "duos_sd.img.lz4",]
+
+[provisionable]
+strategy = "dd_v1"
+
+[metadata.vendor]
+name = "milkv-duos"
+eula = ""
+
+[provisionable.partition_map]
+disk = "duos_sd.img"
+
+# This file is created by program Sync Package Index inside support-matrix
+# Run ID: 14352853976
+# Run URL: https://github.com/wychlw/support-matrix/actions/runs/14352853976

--- a/provisioner/config.yml
+++ b/provisioner/config.yml
@@ -539,6 +539,10 @@ image_combos:
     display_name: buildroot v1 for Milk-V Duo (256M)
     packages:
       - board-image/buildroot-sdk-milkv-duo-256m-v1
+  - id: debian-milkv-duos-sd
+    display_name: debian sd for Milk-V Duo S
+    packages:
+      - board-image/debian-milkv-duos-sd
 devices:
   - id: awol-d1dev
     display_name: "Allwinner Nezha D1"
@@ -599,6 +603,7 @@ devices:
         display_name: "Milk-V Duo S (generic variant)"
         supported_combos:
           - buildroot-sdk-milkv-duos-sd-v2
+          - debian-milkv-duos-sd
   - id: milkv-mars
     display_name: "Milk-V Mars"
     variants:


### PR DESCRIPTION

Bump image debian in device milkv-duos to version v1.4.0

Ident: 6ac27e992c1057c89212c383c70dada87f286471c302b0f2568a43da2205f765

This PR is created by program Sync Package Index inside support-matrix

Run ID: 14352853976
Run URL: https://github.com/wychlw/support-matrix/actions/runs/14352853976
