### PR TITLE
Bump image bianbu in device bpi-f3 to version 2.1.1

### DIFF
--- a/manifests/board-image/bianbu-bpi-f3-desktop/2.1.1-0.toml
+++ b/manifests/board-image/bianbu-bpi-f3-desktop/2.1.1-0.toml
@@ -1,0 +1,33 @@
+format = "v1"
+[[distfiles]]
+name = "bianbu-24.04-desktop-k1-v2.1.1-release-20250305144026.img.zip"
+size = 2616243211
+urls = [ "https://archive.spacemit.com/image/k1/version/bianbu/v2.1.1/bianbu-24.04-desktop-k1-v2.1.1-release-20250305144026.img.zip",]
+restrict = [ "mirror",]
+
+[distfiles.checksums]
+sha256 = "a42a0efc1c55f4942b081a9fc444a9dec853ff165c1fd8cd4775539cc64ed408"
+sha512 = "36adc5b8de585a1a88df9f5d640d12f743ac213747c694116cb0d6a0adb98d50388e891c8952675816beac3d904c1ce2d2b44126477a005cd2dda739d2f210b9"
+
+[metadata]
+desc = "Official bianbu desktop image for Banana Pi F3 version 2.1.1"
+upstream_version = "2.1.1"
+[[metadata.service_level]]
+level = "good"
+
+[blob]
+distfiles = [ "bianbu-24.04-desktop-k1-v2.1.1-release-20250305144026.img.zip",]
+
+[provisionable]
+strategy = "dd_v1"
+
+[metadata.vendor]
+name = "bpi-f3"
+eula = ""
+
+[provisionable.partition_map]
+disk = "bianbu-24.04-desktop-k1-v2.1.1-release-20250305144026.img"
+
+# This file is created by program Sync Package Index inside support-matrix
+# Run ID: 14356174136
+# Run URL: https://github.com/wychlw/support-matrix/actions/runs/14356174136

--- a/provisioner/config.yml
+++ b/provisioner/config.yml
@@ -541,12 +541,16 @@ image_combos:
   - id: debian-milkv-duo-256m
     display_name: debian  for Milk-V Duo (256M)
     packages:
-      - board-image/debian-milkv-duo-256m      
+      - board-image/debian-milkv-duo-256m
 
 #
 # Supported devices
 #
 
+  - id: bianbu-bpi-f3-desktop
+    display_name: bianbu desktop for BananaPi BPI-F3
+    packages:
+      - board-image/bianbu-bpi-f3-desktop
 devices:
   - id: awol-d1dev
     display_name: "Allwinner Nezha D1"
@@ -982,3 +986,4 @@ devices:
         display_name: BananaPi BPI-F3 (generic)
         supported_combos:
           - bianbu-bpi-f3
+          - bianbu-bpi-f3-desktop


### PR DESCRIPTION

Bump image bianbu in device bpi-f3 to version 2.1.1

Ident: bdf06f1839ea2f8edff59a0d918a5fd05ab58e698c28fdaa0caccd3a9111ea44

This PR is created by program Sync Package Index inside support-matrix

Run ID: 14356174136
Run URL: https://github.com/wychlw/support-matrix/actions/runs/14356174136
