### PR TITLE
Bump image bianbu in device bpi-f3 to version 2.1.1

### DIFF
--- a/manifests/board-image/bianbu-bpi-f3-minimal/2.1.1-0.toml
+++ b/manifests/board-image/bianbu-bpi-f3-minimal/2.1.1-0.toml
@@ -1,0 +1,32 @@
+format = "v1"
+[[distfiles]]
+name = "bianbu-24.04-minimal-k1-v2.1.1-release-20250305135614.img.zip"
+size = 251760889
+urls = [ "https://archive.spacemit.com/image/k1/version/bianbu/v2.1.1/bianbu-24.04-minimal-k1-v2.1.1-release-20250305135614.img.zip",]
+restrict = [ "mirror",]
+
+[distfiles.checksums]
+sha256 = "ffc60ca14323042733be5e2e8aab97626f4c3b3ae9167f2e96b2d5180d0b3092"
+sha512 = "4400235aea48aa6ba9871ff6694ec5045e9c98f3db8d51086c4a0e44b3f8a92e5ae0f7fdea09d22701ccab7f5c9b45fb0bdcebb11039cd8d89c8764e05be5c87"
+
+[metadata]
+desc = "Official bianbu minimal image for Banana Pi F3 version 2.1.1"
+service_level = []
+upstream_version = "2.1.1"
+
+[blob]
+distfiles = [ "bianbu-24.04-minimal-k1-v2.1.1-release-20250305135614.img.zip",]
+
+[provisionable]
+strategy = "dd_v1"
+
+[metadata.vendor]
+name = "bpi-f3"
+eula = ""
+
+[provisionable.partition_map]
+disk = "bianbu-24.04-minimal-k1-v2.1.1-release-20250305135614.img"
+
+# This file is created by program Sync Package Index inside support-matrix
+# Run ID: 14392939664
+# Run URL: https://github.com/wychlw/support-matrix/actions/runs/14392939664

--- a/provisioner/config.yml
+++ b/provisioner/config.yml
@@ -541,12 +541,16 @@ image_combos:
   - id: debian-milkv-duo-256m
     display_name: debian  for Milk-V Duo (256M)
     packages:
-      - board-image/debian-milkv-duo-256m      
+      - board-image/debian-milkv-duo-256m
 
 #
 # Supported devices
 #
 
+  - id: bianbu-bpi-f3-minimal
+    display_name: bianbu minimal for BananaPi BPI-F3
+    packages:
+      - board-image/bianbu-bpi-f3-minimal
 devices:
   - id: awol-d1dev
     display_name: "Allwinner Nezha D1"
@@ -982,3 +986,4 @@ devices:
         display_name: BananaPi BPI-F3 (generic)
         supported_combos:
           - bianbu-bpi-f3
+          - bianbu-bpi-f3-minimal


### PR DESCRIPTION

Bump image bianbu in device bpi-f3 to version 2.1.1

Ident: ffaa39d64c8d69e797cb5434da73ad9b8b0d80bcdf7ea5479caae015f1ff459f

This PR is created by program Sync Package Index inside support-matrix

Run ID: 14392939664
Run URL: https://github.com/wychlw/support-matrix/actions/runs/14392939664
