### PR TITLE
Bump image openeuler in device sipeed-lpi4a to version 24.03-LTS-SP1

### DIFF
--- a/manifests/board-image/oerv-sipeed-lpi4a-LTS/24.3.0-1-LTS.toml
+++ b/manifests/board-image/oerv-sipeed-lpi4a-LTS/24.3.0-1-LTS.toml
@@ -1,0 +1,43 @@
+format = "v1"
+[[distfiles]]
+name = "openEuler-24.03-LTS-SP1-riscv64-lpi4a-base-boot.ext4.zst"
+size = 239970775
+urls = [ "https://fast-mirror.isrc.ac.cn/openeuler/openEuler-24.03-LTS-SP1/embedded_img/riscv64/lpi4a/openEuler-24.03-LTS-SP1-riscv64-lpi4a-base-boot.ext4.zst",]
+restrict = [ "mirror",]
+
+[distfiles.checksums]
+sha256 = "d6c2b735b4df5f5e33423ee41a739e9442118aaa0f0b83791d83b7017cb95ab8"
+sha512 = "3d368b0432ee4eac286c76bfdb675d46704d8db9d2c6ff54d9825942695c73dc67321e53676416a611b263d319a1c5c9f4726becaa08294ec757bda3341519e1"
+[[distfiles]]
+name = "openEuler-24.03-LTS-SP1-riscv64-lpi4a-base-root.ext4.zst"
+size = 1039745696
+urls = [ "https://fast-mirror.isrc.ac.cn/openeuler/openEuler-24.03-LTS-SP1/embedded_img/riscv64/lpi4a/openEuler-24.03-LTS-SP1-riscv64-lpi4a-base-root.ext4.zst",]
+restrict = [ "mirror",]
+
+[distfiles.checksums]
+sha256 = "fda5174503f4f5323c56575d651f4e14296f44683483cf6c887c0fce0f75b9f6"
+sha512 = "4424a54e590d0d89d8d422a1409ee7cba064e1d6a2ac883db8760d23de81c7fdfcfd741d81898291c033c755755b5a22489d95ee0561082d5edf9e6b30334824"
+
+[metadata]
+desc = "openEuler 24.03-LTS-SP1 image for Sipeed LicheePi 4A"
+upstream_version = "24.03-LTS-SP1"
+[[metadata.service_level]]
+level = "good"
+
+[blob]
+distfiles = [ "openEuler-24.03-LTS-SP1-riscv64-lpi4a-base-boot.ext4.zst", "openEuler-24.03-LTS-SP1-riscv64-lpi4a-base-root.ext4.zst",]
+
+[provisionable]
+strategy = "fastboot-v1"
+
+[metadata.vendor]
+name = "sipeed-lpi4a"
+eula = ""
+
+[provisionable.partition_map]
+boot = "openEuler-24.03-LTS-SP1-riscv64-lpi4a-base-boot.ext4.zst"
+root = "openEuler-24.03-LTS-SP1-riscv64-lpi4a-base-root.ext4.zst"
+
+# This file is created by program Sync Package Index inside support-matrix
+# Run ID: 14393546464
+# Run URL: https://github.com/wychlw/support-matrix/actions/runs/14393546464

--- a/manifests/board-image/uboot-oerv-sipeed-lpi4a-16g-LTS/24.3.0-1-LTS.toml
+++ b/manifests/board-image/uboot-oerv-sipeed-lpi4a-16g-LTS/24.3.0-1-LTS.toml
@@ -1,0 +1,33 @@
+format = "v1"
+[[distfiles]]
+name = "u-boot-with-spl-lpi4a-16g.bin"
+size = 992712
+urls = [ "https://fast-mirror.isrc.ac.cn/openeuler/openEuler-24.03-LTS-SP1/embedded_img/riscv64/lpi4a/u-boot-with-spl-lpi4a-16g.bin",]
+restrict = [ "mirror",]
+
+[distfiles.checksums]
+sha256 = "39b05820158b04269b5ad4f704ba5610c5caed3e7496a25834a3304af2a1ba9c"
+sha512 = "eae7af0d09b445f9c0ba16d1420cbda4a915b779923c22ac1a6452d63b3d2456b4ea1bfddafc074cbfc8424ed8d725c4beefcfc3714dc7d81b4d8dbd510b50b7"
+
+[metadata]
+desc = "U-Boot image for LicheePi 4A (16G RAM) and openEuler 24.03-LTS-SP1"
+upstream_version = "24.03-LTS-SP1"
+[[metadata.service_level]]
+level = "good"
+
+[blob]
+distfiles = [ "u-boot-with-spl-lpi4a-16g.bin",]
+
+[provisionable]
+strategy = "fastboot-v1"
+
+[metadata.vendor]
+name = "sipeed-lpi4a"
+eula = ""
+
+[provisionable.partition_map]
+uboot = "u-boot-with-spl-lpi4a-16g.bin"
+
+# This file is created by program Sync Package Index inside support-matrix
+# Run ID: 14393546464
+# Run URL: https://github.com/wychlw/support-matrix/actions/runs/14393546464

--- a/manifests/board-image/uboot-oerv-sipeed-lpi4a-8g-LTS/24.3.0-1-LTS.toml
+++ b/manifests/board-image/uboot-oerv-sipeed-lpi4a-8g-LTS/24.3.0-1-LTS.toml
@@ -1,0 +1,33 @@
+format = "v1"
+[[distfiles]]
+name = "u-boot-with-spl-lpi4a.bin"
+size = 1032280
+urls = [ "https://fast-mirror.isrc.ac.cn/openeuler/openEuler-24.03-LTS-SP1/embedded_img/riscv64/lpi4a/u-boot-with-spl-lpi4a.bin",]
+restrict = [ "mirror",]
+
+[distfiles.checksums]
+sha256 = "b2732a56f2b5d5e642804e94a55754b6b6dae54d02ac5ca4249d1df59931e391"
+sha512 = "b699b4a7276501c32057bef7d87fe939ade9a15d9754163f8da59c0f4d97c5f2ecceb5549e1cbbfe3c3b0e757bdf07a6d0f731ee0c270e990233d55176415284"
+
+[metadata]
+desc = "U-Boot image for LicheePi 4A (8G RAM) and openEuler 24.03-LTS-SP1"
+upstream_version = "24.03-LTS-SP1"
+[[metadata.service_level]]
+level = "good"
+
+[blob]
+distfiles = [ "u-boot-with-spl-lpi4a.bin",]
+
+[provisionable]
+strategy = "fastboot-v1"
+
+[metadata.vendor]
+name = "sipeed-lpi4a"
+eula = ""
+
+[provisionable.partition_map]
+uboot = "u-boot-with-spl-lpi4a.bin"
+
+# This file is created by program Sync Package Index inside support-matrix
+# Run ID: 14393546464
+# Run URL: https://github.com/wychlw/support-matrix/actions/runs/14393546464

--- a/provisioner/config.yml
+++ b/provisioner/config.yml
@@ -555,6 +555,11 @@ image_combos:
     display_name: bianbu minimal for BananaPi BPI-F3
     packages:
       - board-image/bianbu-bpi-f3-minimal
+  - id: oerv-sipeed-lpi4a-16g-LTS
+    display_name: openeuler LTS for LicheePi 4A
+    packages:
+      - board-image/uboot-oerv-sipeed-lpi4a-16g-LTS
+      - board-image/oerv-sipeed-lpi4a-16g-LTS
 devices:
   - id: awol-d1dev
     display_name: "Allwinner Nezha D1"
@@ -740,6 +745,7 @@ devices:
           - oerv-sipeed-lpi4a-16g-xfce
           - revyos-sipeed-lpi4a-16g
 
+          - oerv-sipeed-lpi4a-16g-LTS
   - id: sipeed-licheerv
     display_name: "Sipeed Lichee RV"
     variants:


### PR DESCRIPTION

Bump image openeuler in device sipeed-lpi4a to version 24.03-LTS-SP1

Ident: 3c3552bac01e63c9327b306088f07df54e5f813b26d837994424b2f3759c8e73

This PR is created by program Sync Package Index inside support-matrix

Run ID: 14393546464
Run URL: https://github.com/wychlw/support-matrix/actions/runs/14393546464
