### PR TITLE
Bump image openwrt in device sifive-unmatched to version 24.10.0

### DIFF
--- a/manifests/board-image/openwrt-sifive-unmatched/24.10.0-0.toml
+++ b/manifests/board-image/openwrt-sifive-unmatched/24.10.0-0.toml
@@ -1,0 +1,32 @@
+format = "v1"
+[[distfiles]]
+name = "openwrt-24.10.0-sifiveu-generic-sifive_unmatched-ext4-sdcard.img.gz"
+size = 2761
+urls = [ "https://mirrors.tuna.tsinghua.edu.cn/openwrt/releases/24.10.0/targets/sifiveu/generic/openwrt-24.10.0-sifiveu-generic-sifive_unmatched-ext4-sdcard.img.gz",]
+restrict = [ "mirror",]
+
+[distfiles.checksums]
+sha256 = "76070ed4db2c21cef45083841b2136dd462821d14593febe78801ecd3af670a3"
+sha512 = "3c053f13e0c55b22e9c0e66ebc199d042e0acceee2fd78f72110735295a21ff847acf07bf9b53de6406694bcbe151d5171a8febff72b0d4318f42c643efa12ca"
+
+[metadata]
+desc = "Official OpenWRT 24.10.0 image for SiFive Unmatched"
+service_level = []
+upstream_version = "24.10.0"
+
+[blob]
+distfiles = [ "openwrt-24.10.0-sifiveu-generic-sifive_unmatched-ext4-sdcard.img.gz",]
+
+[provisionable]
+strategy = "dd_v1"
+
+[metadata.vendor]
+name = "OpenWrt"
+eula = ""
+
+[provisionable.partition_map]
+disk = "openwrt-24.10.0-sifiveu-generic-sifive_unmatched-ext4-sdcard.img"
+
+# This file is created by program Sync Package Index inside support-matrix
+# Run ID: 14399655753
+# Run URL: https://github.com/wychlw/support-matrix/actions/runs/14399655753


### PR DESCRIPTION

Bump image openwrt in device sifive-unmatched to version 24.10.0

Ident: ae9d810917b9ca2023799a66dd92be3cda40516dfb386f6339d6f661d7129345

This PR is created by program Sync Package Index inside support-matrix

Run ID: 14399655753
Run URL: https://github.com/wychlw/support-matrix/actions/runs/14399655753
