### PR TITLE
Bump image openwrt in device sifive-unmatched to version 24.10.0

### DIFF
--- a/manifests/board-image/openwrt-sifive-unmatched/2410.0.0.toml
+++ b/manifests/board-image/openwrt-sifive-unmatched/2410.0.0.toml
@@ -1,0 +1,30 @@
+format = "v1"
+[[distfiles]]
+name = "openwrt-24.10.0-sifiveu-generic-sifive_unmatched-ext4-sdcard.img.gz"
+size = 9306246
+urls = [ "https://downloads.openwrt.org/releases/24.10.0/targets/sifiveu/generic/openwrt-24.10.0-sifiveu-generic-sifive_unmatched-ext4-sdcard.img.gz",]
+restrict = [ "mirror",]
+
+[distfiles.checksums]
+sha256 = "2d42cc09ca57c2df21c844c8027d0d79301a716856d56234699397dc24e1f43e"
+sha512 = "9346e3577eb2042f4471c05325dccab6c3c437b262c0753076dabe45f07f11a50746b4eb576e1a09e89040bb9140750101906ad3b72b8be5df3c64a815d44faa"
+
+[metadata]
+desc = "Official OpenWRT 24.10.0 image for SiFive Unmatched"
+service_level = []
+upstream_version = "24.10.0"
+
+[blob]
+distfiles = [ "openwrt-24.10.0-sifiveu-generic-sifive_unmatched-ext4-sdcard.img.gz",]
+
+[provisionable]
+strategy = "dd-v1"
+
+[metadata.vendor]
+name = "OpenWrt"
+eula = ""
+
+[provisionable.partition_map]
+disk = "openwrt-24.10.0-sifiveu-generic-sifive_unmatched-ext4-sdcard.img"
+
+# This file is created by program Sync Package Index inside support-matrix


### PR DESCRIPTION

Bump image openwrt in device sifive-unmatched to version 24.10.0

Ident: 03716ed4c077d29dcbe06c00037233848d0013103bccf3191f77c19fbf30ef32

This PR is created by program Sync Package Index inside support-matrix


