### PR TITLE
Bump image ubuntu in device sifive-unmatched to version 24.10

### DIFF
--- a/manifests/board-image/ubuntu-sifive-unmatched/2410.0.0.toml
+++ b/manifests/board-image/ubuntu-sifive-unmatched/2410.0.0.toml
@@ -1,0 +1,30 @@
+format = "v1"
+[[distfiles]]
+name = "ubuntu-24.10-preinstalled-server-riscv64%2Bunmatched.img.xz"
+size = 1032701560
+urls = [ "https://mirror.iscas.ac.cn/ubuntu-cdimage/releases/24.10/release/ubuntu-24.10-preinstalled-server-riscv64%2Bunmatched.img.xz",]
+restrict = [ "mirror",]
+
+[distfiles.checksums]
+sha256 = "aff591c54a782f8068523fd8ffa4a2721c4959902b578778bb3cdcbec8934f28"
+sha512 = "308880616455b6006a2c50cebb21b1e6596f29acc51f9bccdb36eb964d468ec9a1fce4d2c00faac0cc1997ffb622bce57cc3990ac166b3f159a701efc34ccc98"
+
+[metadata]
+desc = "Official Ubuntu 24.10 Server image for SiFive HiFive Unmatched"
+service_level = []
+upstream_version = "24.10"
+
+[blob]
+distfiles = [ "ubuntu-24.10-preinstalled-server-riscv64%2Bunmatched.img.xz",]
+
+[provisionable]
+strategy = "dd-v1"
+
+[metadata.vendor]
+name = "sifive-unmatched"
+eula = ""
+
+[provisionable.partition_map]
+disk = "ubuntu-24.10-preinstalled-server-riscv64%2Bunmatched.img"
+
+# This file is created by program Sync Package Index inside support-matrix


### PR DESCRIPTION

Bump image ubuntu in device sifive-unmatched to version 24.10

Ident: 27bb81b80d636557631c3fe2027ecf4f87ce30de6f8ee622315cdf4efaaa7051

This PR is created by program Sync Package Index inside support-matrix


