### PR TITLE
Bump image armbian in device pine64-star64 to version 25.2.0-trunk.124

### DIFF
--- a/manifests/board-image/armbian-pine64-star64/2502.0.124.toml
+++ b/manifests/board-image/armbian-pine64-star64/2502.0.124.toml
@@ -1,0 +1,31 @@
+format = "v1"
+[[distfiles]]
+name = "Armbian_community_25.2.0-trunk.124_Star64_noble_edge_5.15.0_minimal.img.xz"
+size = 220427108
+urls = [ "https://github.com/armbian/community/releases/download/25.2.0-trunk.124/Armbian_community_25.2.0-trunk.124_Star64_noble_edge_5.15.0_minimal.img.xz",]
+restrict = [ "mirror",]
+
+[distfiles.checksums]
+sha256 = "0feedf2bcb4cb7eb75421645b83e4cca4c371e2450254a49de75ae6a5dfb5bc4"
+sha512 = "e9dbabef369237e423b9b3d052a93bcd3ac8c7dc096670230e3457991224a2e8d04b6033453d9e37923fb6b4fdd4ba5ab3832b248d40a38dc75e35e4726f1dec"
+
+[metadata]
+desc = "armbian  for Star64 with version 25.2.0-trunk.124"
+upstream_version = "25.2.0-trunk.124"
+[[metadata.service_level]]
+level = "known_issue"
+
+[blob]
+distfiles = [ "Armbian_community_25.2.0-trunk.124_Star64_noble_edge_5.15.0_minimal.img.xz",]
+
+[provisionable]
+strategy = "dd-v1"
+
+[metadata.vendor]
+name = "Armbian"
+eula = ""
+
+[provisionable.partition_map]
+disk = "Armbian_community_25.2.0-trunk.124_Star64_noble_edge_5.15.0_minimal.img"
+
+# This file is created by program Sync Package Index inside support-matrix


### PR DESCRIPTION

Bump image armbian in device pine64-star64 to version 25.2.0-trunk.124

Ident: 95160ad931abbff5eaff6b03cf0d788b9a71ce012ab9fc20a30c78e5ec329e62

This PR is created by program Sync Package Index inside support-matrix


