### PR TITLE
Bump image bianbu in device bpi-f3 to version 2.1.1

### DIFF
--- a/manifests/board-image/bianbu-bpi-f3-desktop/2.1.1.toml
+++ b/manifests/board-image/bianbu-bpi-f3-desktop/2.1.1.toml
@@ -1,0 +1,31 @@
+format = "v1"
+[[distfiles]]
+name = "bianbu-24.04-desktop-k1-v2.1.1-release-20250305144026.img.zip"
+size = 560652288
+urls = [ "https://archive.spacemit.com/image/k1/version/bianbu/v2.1.1/bianbu-24.04-desktop-k1-v2.1.1-release-20250305144026.img.zip",]
+restrict = [ "mirror",]
+
+[distfiles.checksums]
+sha256 = "8dabd17c30bdb2c0d4e076417a90b6cddca2031e0e19350fd0d4ee29944a953f"
+sha512 = "1318b6207085af38036445fb7e0a1ed87545417ac018c7a4ae7733f1110c3944d3ff0fbfd6f105905efe003f386660bde20efc529206549f99805761c5adbc85"
+
+[metadata]
+desc = "Official bianbu desktop image for Banana Pi F3 version 2.1.1"
+upstream_version = "2.1.1"
+[[metadata.service_level]]
+level = "good"
+
+[blob]
+distfiles = [ "bianbu-24.04-desktop-k1-v2.1.1-release-20250305144026.img.zip",]
+
+[provisionable]
+strategy = "dd-v1"
+
+[metadata.vendor]
+name = "bpi-f3"
+eula = ""
+
+[provisionable.partition_map]
+disk = "bianbu-24.04-desktop-k1-v2.1.1-release-20250305144026.img"
+
+# This file is created by program Sync Package Index inside support-matrix


### PR DESCRIPTION

Bump image bianbu in device bpi-f3 to version 2.1.1

Ident: 3e19b5459e441b4992dc5266ebf007e2bd0843578bf0a3254e943982e00a8787

This PR is created by program Sync Package Index inside support-matrix


