### PR TITLE
Bump image openeuler in device milkv-pioneer to version 24.03-LTS-SP1

### DIFF
--- a/manifests/board-image/firmware-oerv-milkv-pioneer/2403.0.1.toml
+++ b/manifests/board-image/firmware-oerv-milkv-pioneer/2403.0.1.toml
@@ -1,0 +1,31 @@
+format = "v1"
+[[distfiles]]
+name = "sg2042_firmware_linuxboot.img.zip"
+size = 16982087
+urls = [ "https://fast-mirror.isrc.ac.cn/openeuler/openEuler-24.03-LTS-SP1/embedded_img/riscv64/SG2042/sg2042_firmware_linuxboot.img.zip",]
+restrict = [ "mirror",]
+
+[distfiles.checksums]
+sha256 = "1d1e47ce2cbbeda528c4338030f914c4905af89fc939783e3ff80fefa935c57d"
+sha512 = "0fdf299e372f8af01b988afcee3021045ab81d02e6bc3b3a90136f1f36ec3b4452f8fde25023f54bda65651d5cecfb3a9adfa216e8c9e001339a388f51941497"
+
+[metadata]
+desc = "Firmware image for Milk-V Pioneer and openEuler 24.03-LTS-SP1"
+upstream_version = "24.03-LTS-SP1"
+[[metadata.service_level]]
+level = "good"
+
+[blob]
+distfiles = [ "sg2042_firmware_linuxboot.img.zip",]
+
+[provisionable]
+strategy = "dd-v1"
+
+[metadata.vendor]
+name = "milkv-pioneer"
+eula = ""
+
+[provisionable.partition_map]
+disk = "sg2042_firmware_linuxboot.img"
+
+# This file is created by program Sync Package Index inside support-matrix

--- a/manifests/board-image/oerv-milkv-pioneer/2403.0.1.toml
+++ b/manifests/board-image/oerv-milkv-pioneer/2403.0.1.toml
@@ -1,0 +1,31 @@
+format = "v1"
+[[distfiles]]
+name = "openEuler-24.03-LTS-SP1-riscv64-sg2042.img.zip"
+size = 1212720721
+urls = [ "https://fast-mirror.isrc.ac.cn/openeuler/openEuler-24.03-LTS-SP1/embedded_img/riscv64/SG2042/openEuler-24.03-LTS-SP1-riscv64-sg2042.img.zip",]
+restrict = [ "mirror",]
+
+[distfiles.checksums]
+sha256 = "9a99c6a227eaf034f6cb0e44f342a5f3824d08c3f9fc4f58532f44e156f63f47"
+sha512 = "7cadad7929d9010566855519e4b0f0fdb516ce37df6682f6e4b941579da20c521611496f49e53056a8a68bddf8fedd16067ae9a9d4435ca645066894200c1c5d"
+
+[metadata]
+desc = "openEuler 24.03-LTS-SP1 image for Milk-V Pioneer"
+upstream_version = "24.03-LTS-SP1"
+[[metadata.service_level]]
+level = "good"
+
+[blob]
+distfiles = [ "openEuler-24.03-LTS-SP1-riscv64-sg2042.img.zip",]
+
+[provisionable]
+strategy = "dd-v1"
+
+[metadata.vendor]
+name = "milkv-pioneer"
+eula = ""
+
+[provisionable.partition_map]
+disk = "openEuler-24.03-LTS-SP1-riscv64-sg2042.img"
+
+# This file is created by program Sync Package Index inside support-matrix


### PR DESCRIPTION

Bump image openeuler in device milkv-pioneer to version 24.03-LTS-SP1

Ident: 4a4638a4921984485ce44284926b913d3c834c3ab9fe5ac1c75f14d1aee924af

This PR is created by program Sync Package Index inside support-matrix


