### PR TITLE
Bump image openeuler in device milkv-pioneer to version 25.03

### DIFF
--- a/manifests/board-image/firmware-oerv-milkv-pioneer/2503.0.0.toml
+++ b/manifests/board-image/firmware-oerv-milkv-pioneer/2503.0.0.toml
@@ -1,0 +1,31 @@
+format = "v1"
+[[distfiles]]
+name = "sg2042_firmware_linuxboot.img.zip"
+size = 16982087
+urls = [ "https://fast-mirror.isrc.ac.cn/openeuler/openEuler-25.03/embedded_img/riscv64/SG2042/sg2042_firmware_linuxboot.img.zip",]
+restrict = [ "mirror",]
+
+[distfiles.checksums]
+sha256 = "1d1e47ce2cbbeda528c4338030f914c4905af89fc939783e3ff80fefa935c57d"
+sha512 = "0fdf299e372f8af01b988afcee3021045ab81d02e6bc3b3a90136f1f36ec3b4452f8fde25023f54bda65651d5cecfb3a9adfa216e8c9e001339a388f51941497"
+
+[metadata]
+desc = "Firmware image for Milk-V Pioneer and openEuler 25.03"
+upstream_version = "25.03"
+[[metadata.service_level]]
+level = "good"
+
+[blob]
+distfiles = [ "sg2042_firmware_linuxboot.img.zip",]
+
+[provisionable]
+strategy = "dd-v1"
+
+[metadata.vendor]
+name = "milkv-pioneer"
+eula = ""
+
+[provisionable.partition_map]
+disk = "sg2042_firmware_linuxboot.img"
+
+# This file is created by program Sync Package Index inside support-matrix

--- a/manifests/board-image/oerv-milkv-pioneer/2503.0.0.toml
+++ b/manifests/board-image/oerv-milkv-pioneer/2503.0.0.toml
@@ -1,0 +1,31 @@
+format = "v1"
+[[distfiles]]
+name = "openEuler-25.03-riscv64-sg2042.img.zip"
+size = 1444484098
+urls = [ "https://fast-mirror.isrc.ac.cn/openeuler/openEuler-25.03/embedded_img/riscv64/SG2042/openEuler-25.03-riscv64-sg2042.img.zip",]
+restrict = [ "mirror",]
+
+[distfiles.checksums]
+sha256 = "1cb009baf1534aed719123538bf2228e55b0968aeaeaf14f9a981d4a45797b48"
+sha512 = "f1c7f9a7b3fd6e159e33afe93e10dee51b3507f309fb483b50ec45d0bba2b5efe49c19270215dce665f174082c136ea87bd5c21ea275a9ef7d071718ab44e745"
+
+[metadata]
+desc = "openEuler 25.03 image for Milk-V Pioneer"
+upstream_version = "25.03"
+[[metadata.service_level]]
+level = "good"
+
+[blob]
+distfiles = [ "openEuler-25.03-riscv64-sg2042.img.zip",]
+
+[provisionable]
+strategy = "dd-v1"
+
+[metadata.vendor]
+name = "milkv-pioneer"
+eula = ""
+
+[provisionable.partition_map]
+disk = "openEuler-25.03-riscv64-sg2042.img"
+
+# This file is created by program Sync Package Index inside support-matrix


### PR DESCRIPTION

Bump image openeuler in device milkv-pioneer to version 25.03

Ident: 694bf4d8264f2efe8df25780f552b5e8b76a4bd990bf8d8648d624c6b013ad9f

This PR is created by program Sync Package Index inside support-matrix


